### PR TITLE
Fix ts-loader errors on webpack 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "resolve-url-loader": "^2.2.1",
     "sass-loader": "^6.0.5",
     "style-loader": "^0.18.2",
+    "ts-loader": "^3.5.0",
     "uglify-js": "^2.8.29",
     "uglifyjs-webpack-plugin": "^1.1.8",
     "vue-loader": "^13.7.1",


### PR DESCRIPTION
Fix error encountered on this issue
https://github.com/TypeStrong/ts-loader/issues/729

This will force usage of old ts-loader version, that is compatible with webpack 3. ts-loader 4 expects webpack 4.